### PR TITLE
Add property to allow for apns-push-type header

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ And it also supports multiple stream at one connection.
 
     Sets the apns-collapse-id header.
 
+- apns\_push\_type : string
+
+    Sets the apns-push-type header.
+
 - proxy : string
 
     URL of a proxy server. Default $ENV{https\_proxy}. Pass undef to disable proxy.

--- a/lib/Net/APNS/Simple.pm
+++ b/lib/Net/APNS/Simple.pm
@@ -24,7 +24,7 @@ has [qw/proxy/] => (
     default => $ENV{https_proxy},
 );
 
-has [qw/apns_id apns_expiration apns_collapse_id/] => (
+has [qw/apns_id apns_expiration apns_collapse_id apns_push_type/] => (
     is => 'rw',
 );
 
@@ -107,7 +107,7 @@ sub prepare {
         'apns-topic' => $self->bundle_id,
     );
 
-    for (qw/apns_id apns_priority apns_expiration apns_collapse_id/) {
+    for (qw/apns_id apns_priority apns_expiration apns_collapse_id apns_push_type/) {
         my $v = $self->$_;
         next unless defined $v;
         my $k = $_;
@@ -309,6 +309,10 @@ Sets the apns-priority header. Default 10.
 =item apns_collapse_id : string
 
 Sets the apns-collapse-id header.
+
+=item apns_push_type : string
+
+Sets the apns-push-type header.
 
 =item proxy : string
 

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -10,6 +10,7 @@ my $apns = new_ok('Net::APNS::Simple' => [
     development     => 0,
     apns_expiration => 0,
     apns_priority   => 5,
+    apns_push_type  => 'background',
 ]);
 
 is($apns->auth_key => 'SAMPLE.p8');
@@ -19,6 +20,7 @@ is($apns->bundle_id => 'opqrstu');
 is($apns->development => 0);
 is($apns->apns_expiration => 0);
 is($apns->apns_priority => 5);
+is($apns->apns_push_type => 'background');
 is($apns->algorithm => 'ES256');
 is($apns->_host => 'api.push.apple.com');
 $apns->development(1);


### PR DESCRIPTION
Needed this to be able to send background push messages, would be nice to have it integrated with CPAN distribution :-)

Documentation:
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns

